### PR TITLE
fix: update Render publish path from build to dist

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: doneperiod-client
     runtime: static
     buildCommand: npm install && npm run build
-    staticPublishPath: ./build
+    staticPublishPath: ./dist
     pullRequestPreviewsEnabled: false
     routes:
       - type: rewrite


### PR DESCRIPTION
Vite outputs to dist/ not build/ (CRA default).